### PR TITLE
🎨 style : 글목록 페이지 레이아웃 초안

### DIFF
--- a/Client/src/Components/AsideRight.js
+++ b/Client/src/Components/AsideRight.js
@@ -6,8 +6,9 @@ const Container = styled.aside`
   width: 300px;
   background-color: rgb(251, 243, 213);
   color: rgb(97, 103, 106);
-  margin-top: 20px; // 추후 다른 컴포넌트와 합칠때 고려한 마진입니다.
+  margin-top: 75px; // 추후 다른 컴포넌트와 합칠때 고려한 마진입니다.
   margin-left: 20px; // 추후 다른 컴포넌트와 합칠때 고려한 마진입니다.
+  height: 100%;
 `;
 
 const WrapperOdd = styled.div`
@@ -38,7 +39,6 @@ const A = styled.a`
   line-height: 17px;
   text-decoration: none;
   color: rgb(97, 103, 106);
-
   &:hover {
     color: rgb(97, 103, 106);
   }

--- a/Client/src/components/AsideLeft.js
+++ b/Client/src/components/AsideLeft.js
@@ -6,12 +6,12 @@ import * as Icons from '@stackoverflow/stacks-icons';
 const Container = styled.aside`
   width: 155px;
   margin-left: 10px;
-  margin-top: 20px; // 추후 다른 컴포넌트와 합칠때 고려한 마진입니다.
+  margin-top: 75px; // 추후 다른 컴포넌트와 합칠때 고려한 마진입니다.
+  position: fixed;
 `;
 
 const TopBox = styled.div`
   padding: 10px 0px;
-
   h1 {
     font-size: 13px;
     line-height: 26px;
@@ -39,13 +39,11 @@ const WrapperTab = styled.div`
     height: 290px;
     margin-left: -10px;
     padding: 15px;
-
     span {
       font-size: 13px;
       line-height: 17px;
       color: #525960;
     }
-
     span:first-child {
       color: #2f3337;
       font-weight: bolder;
@@ -56,7 +54,7 @@ const WrapperTab = styled.div`
 const Ul = styled.ul`
   div {
     position: absolute;
-    top: 107px;
+    top: 93px;
     font-size: 13px;
   }
 `;
@@ -89,7 +87,6 @@ const BtnCreateTeam = styled.a`
   border-radius: 3px;
   box-shadow: rgba(255, 255, 255, 0.4) 0px 1px 0px 0px inset;
   font-weight: 600;
-
   &:hover {
     color: white;
   }
@@ -99,7 +96,6 @@ const BtnWhyTeam = styled(BtnCreateTeam)`
   background-color: white;
   color: #6a737c;
   font-weight: 400;
-
   &:hover {
     color: #6a737c;
     background-color: #f8f9f9;

--- a/Client/src/components/List.js
+++ b/Client/src/components/List.js
@@ -1,0 +1,138 @@
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import axios from 'axios';
+
+const Container = styled.main`
+  @media screen and (min-width: 1261px) {
+    width: 750px;
+  }
+  @media screen and (max-width: 1260px) {
+    width: 59.5vw;
+  }
+  margin-top: 50px;
+  border-left: 1px solid rgb(219, 222, 224);
+`;
+
+const Section = styled.section`
+  padding-left: 25px;
+  padding-top: 25px;
+  &:last-child {
+    padding-left: 0px;
+  }
+`;
+
+const Wrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 38px;
+  &:first-child {
+    margin-bottom: 20px;
+  }
+`;
+
+const Title = styled.h1`
+  font-size: 27px;
+  font-weight: 500;
+  line-height: 35px;
+`;
+
+const NumOfArticle = styled.h2`
+  font-size: 17px;
+  line-height: 22px;
+  color: #232629;
+`;
+
+const BtnWrite = styled.button`
+  color: #ffffff;
+  background-color: #0a95ff;
+  font-size: 13px;
+  line-height: 15px;
+  text-align: center;
+  padding: 10px;
+  border: none;
+  border-radius: 3px;
+  box-shadow: rgba(255, 255, 255, 0.4) 0px 1px 0px 0px inset;
+  &:hover {
+    cursor: pointer;
+    background-color: #0074cc;
+  }
+`;
+
+const BtnSort = styled.button`
+  font-size: 12px;
+  padding: 10px;
+  color: #6a737c;
+  background-color: white;
+  border: 1px solid rgb(140, 148, 156);
+  &:hover {
+    background-color: #f8f9f9;
+    cursor: pointer;
+  }
+  &:first-child {
+    color: #3b4045;
+    background-color: #e3e6e8;
+  }
+`;
+
+const Ul = styled.ul``;
+
+const Li = styled.li`
+  border-top: 1px solid rgb(219, 222, 224);
+  padding: 20px;
+  color: white;
+`;
+
+function List() {
+  const [posts, setePosts] = useState([]);
+
+  const fetchPosts = async () => {
+    const response = await axios.get('https://koreanjson.com/posts');
+    setePosts(response.data);
+  };
+
+  useEffect(() => {
+    fetchPosts();
+  }, []);
+  return (
+    <Container>
+      <Section>
+        <Wrapper>
+          <Title>All Questions</Title>
+          <BtnWrite>Ask Question</BtnWrite>
+        </Wrapper>
+        <Wrapper>
+          <NumOfArticle>23,156,270 questions</NumOfArticle>
+          <div>
+            <BtnSort>Newest</BtnSort>
+            <BtnSort>Views</BtnSort>
+            <BtnSort>Votes</BtnSort>
+          </div>
+        </Wrapper>
+      </Section>
+      <Section>
+        <Ul>
+          {posts.slice(0, 30).map(post => (
+            <Li key={post.id}>
+              <div>
+                <span>{`${post.id} votes`}</span>
+                <span>{`${post.id} answers`}</span>
+                <span>{`${post.id} views`}</span>
+              </div>
+              <div>
+                <h1>{post.title}</h1>
+                <p>{post.content}</p>
+                <div>
+                  <div>linux, terminal, debian, gnome, ps1</div>
+                  <span>{`${post.UserId}`}</span>
+                </div>
+              </div>
+            </Li>
+          ))}
+        </Ul>
+      </Section>
+    </Container>
+  );
+}
+
+export default List;

--- a/Client/src/pages/BoardList.js
+++ b/Client/src/pages/BoardList.js
@@ -1,7 +1,42 @@
 import React from 'react';
+import styled from 'styled-components';
+import Nav from '../components/Nav';
+import AsideLeft from '../components/AsideLeft';
+import List from '../components/List';
+import AsideRight from '../components/AsideRight';
+
+const WrapperAll = styled.div`
+  display: flex;
+`;
+
+const WrapperNav = styled.div`
+  height: 55px;
+`;
+
+const WrapperBody = styled.div`
+  margin: 0 auto;
+`;
+
+const WrapperMain = styled.div`
+  display: flex;
+  margin-left: 165px;
+`;
 
 function BoardList() {
-  return <div />;
+  return (
+    <WrapperAll>
+      <WrapperNav>
+        <Nav />
+      </WrapperNav>
+      <WrapperBody>
+        <AsideLeft />
+        <WrapperMain>
+          <List />
+          <AsideRight />
+        </WrapperMain>
+      </WrapperBody>
+    </WrapperAll>
+  );
 }
 
 export default BoardList;


### PR DESCRIPTION
### 글목록 페이지 레이아웃 초안

- 페이지 네이션과 글 summary 적용을 제외한 레이아웃입니다
- `Nav` 컴포넌트와 합치면서 `AsideLeft`, `AsideRight` 컴포넌트들의 스타일이 조금 변경 되었습니다.
    - 바뀐 부분 빨리 확인하게 해드리기 위해 글목록 페이지 초안으로 PR 한 번 올립니다.
- `List` 컴포넌트 새롭게 생성하여 작업 중입니다.
- `BoardList` 페이지에 `Nav`, `AsideLeft`, `AsideRight`, `List` 컴포넌트들을 합치고 있습니다.
- 예시 영상

https://user-images.githubusercontent.com/101603474/198085826-cad3bb85-4dd1-4bef-ae25-4e76947b921c.mov


