### PR TITLE
🐛 fix : 시간 렌더링 오류 수정

### DIFF
--- a/Client/src/components/List.js
+++ b/Client/src/components/List.js
@@ -234,7 +234,7 @@ function List() {
   const navigate = useNavigate();
 
   const howManyTimesAgo = createdAtUTC => {
-    const createdAt = Date.parse(createdAtUTC);
+    const createdAt = Date.parse(createdAtUTC.replace('T', 'Z'));
     const diffSeconds = Math.round((Date.now() - createdAt) / 1000);
 
     if (diffSeconds < 60) {
@@ -263,7 +263,7 @@ function List() {
       return '2 days ago';
     }
 
-    const dateCreatedAt = new Date(createdAt);
+    const dateCreatedAt = new Date(createdAt - 32400000);
 
     const month = [
       'Jan',


### PR DESCRIPTION
### 시간 렌더링 오류 수정

- 시간 비교 시에는 UTC + 0 기준으로 비교
- 시간 표현 시에는 UTC + 9 기준(한국시간) 으로 표현